### PR TITLE
Test enhancement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 composer.lock
 vendor/
 aliases.*.php
+*.cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,11 @@
 language: php
-dist: trusty
 php:
-- '7.1'
-- '7.2'
+  - '7.1'
+  - '7.2'
+  - '7.3'
+  - '7.4'
 install:
-- composer update
+- composer install
 script:
 - ./vendor/bin/phpunit --coverage-clover ./tests/Logs/clover.xml
 after_script:

--- a/composer.json
+++ b/composer.json
@@ -50,7 +50,8 @@
             "/phpmd.xml",
             "/phpstan.neon",
             "/phpcs.xml",
-            "/tests"
+            "/tests",
+            "/grumphp.yml"
         ]
     },
     "config": {


### PR DESCRIPTION
# Changed log
- Add `*.cache` to let cached files avoid being under Git version control.
- The `composer.lock` is ignored on Git version control, it's fine to use `composer install` command on Travis CI build.
- Add `php-7.3` and `php-7.4` version tests on Travis CI build.
- Add EOF (the end of file) for some files.